### PR TITLE
Build 5

### DIFF
--- a/ReadRate.xcodeproj/project.pbxproj
+++ b/ReadRate.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -475,7 +475,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -498,7 +498,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookIntentsExtension/SelectedBookIntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookIntentsExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -521,7 +521,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookIntentsExtension/SelectedBookIntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookIntentsExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -662,7 +662,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ReadRate/Read Rate.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"ReadRate/Preview Content\"";
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				ENABLE_PREVIEWS = YES;
@@ -687,7 +687,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ReadRate/Read Rate.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 4;
+				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_ASSET_PATHS = "\"ReadRate/Preview Content\"";
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				ENABLE_PREVIEWS = YES;

--- a/ReadRate.xcodeproj/xcuserdata/evanfreeze.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ReadRate.xcodeproj/xcuserdata/evanfreeze.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,12 +12,12 @@
 		<key>SelectedBookIntentsExtension.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>SelectedBookWidgetExtension.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/ReadRate/Models/BookModel.swift
+++ b/ReadRate/Models/BookModel.swift
@@ -146,6 +146,17 @@ struct Book: Identifiable, Codable, Comparable {
         }
     }
     
+    var displayLastGoalCalculatedDate: String {
+        if let lastCalculatedDate = dailyTargets.last?.calcTime {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .none
+            formatter.timeStyle = .short
+            return formatter.string(from: lastCalculatedDate)
+        } else {
+            return "N/A"
+        }
+    }
+    
     var progressDescription: String {
         if (currentPage == pageCount) {
             return "You finished the book — congrats!"

--- a/ReadRate/Views/BookDetails.swift
+++ b/ReadRate/Views/BookDetails.swift
@@ -12,6 +12,7 @@ struct Card: View {
     let title: String
     let content: String
     let withEdit: Bool
+    let subtitle: String?
     let callback: () -> Void
     
     @State private var rotationAngle = Angle(degrees: 0)
@@ -19,12 +20,19 @@ struct Card: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 4) {
-                HStack {
+                HStack(alignment: .center) {
                     Text(title).rounded(.title3)
                     Spacer()
-                    
                 }
                 Text(content).rounded(.body).foregroundColor(.secondary)
+                if subtitle != nil {
+                    Divider()
+                        .padding(.top, 8)
+                    Text(subtitle!)
+                        .rounded(.caption2, bold: false)
+                        .foregroundColor(.secondary)
+                        .padding(.top, 4)
+                }
             }
             Spacer(minLength: 1)
             if withEdit {
@@ -62,6 +70,14 @@ struct BookDetail: View {
     @State private var showingDeleteAlert = false
     @State private var showingEditSheet = false
     
+    var goalSubtitle: String? {
+        if book.readToday || book.completedAt != nil {
+            return nil
+        } else {
+            return "Goal last updated at \(book.displayLastGoalCalculatedDate)"
+        }
+    }
+    
     var body: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 12) {
@@ -71,10 +87,10 @@ struct BookDetail: View {
                 }
                 
                 ScrollView {
-                    Card(title: "Today's Goal", content: book.progressDescription, withEdit: false) {}
+                    Card(title: "Today's Goal", content: book.progressDescription, withEdit: false, subtitle: goalSubtitle) {}
                     
                     VStack {
-                        Card(title: "Progress", content: "Page \(book.currentPage) of \(book.pageCount) (\(book.percentComplete) complete)", withEdit: true) {
+                        Card(title: "Progress", content: "Page \(book.currentPage) of \(book.pageCount) (\(book.percentComplete) complete)", withEdit: true, subtitle: nil) {
                             editingCurrentPage.toggle()
                         }
                         .shadow(radius: editingCurrentPage ? 3.0 : 0.0)
@@ -101,7 +117,7 @@ struct BookDetail: View {
                     .cornerRadius(20.0)
                     
                     VStack {
-                        Card(title: "Target Completion Date", content: book.displayCompletionTarget, withEdit: true) { editingTargetDate.toggle()
+                        Card(title: "Target Completion Date", content: book.displayCompletionTarget, withEdit: true, subtitle: nil) { editingTargetDate.toggle()
                         }
                         .shadow(radius: editingTargetDate ? 3.0 : 0.0)
                         
@@ -119,10 +135,10 @@ struct BookDetail: View {
                     .background(Color("AltBG"))
                     .cornerRadius(20.0)
                     
-                    Card(title: "Start Date", content: book.displayStartDate, withEdit: false) {}
+                    Card(title: "Start Date", content: book.displayStartDate, withEdit: false, subtitle: nil) {}
                     
                     if book.completedAt != nil {
-                        Card(title: "Finish Date", content: book.displayFinishDate, withEdit: false) {}
+                        Card(title: "Finish Date", content: book.displayFinishDate, withEdit: false, subtitle: nil) {}
                     }
                 }
                 

--- a/ReadRate/Views/BookDetails.swift
+++ b/ReadRate/Views/BookDetails.swift
@@ -74,7 +74,7 @@ struct BookDetail: View {
         if book.readToday || book.completedAt != nil {
             return nil
         } else {
-            return "Goal last updated at \(book.displayLastGoalCalculatedDate)"
+            return "Goal last calculated at \(book.displayLastGoalCalculatedDate)"
         }
     }
     

--- a/SelectedBookIntentsExtension/IntentHandler.swift
+++ b/SelectedBookIntentsExtension/IntentHandler.swift
@@ -9,11 +9,15 @@
 import Intents
 
 class IntentHandler: INExtension, SelectedBookIntentHandling {
-    func resolveParameter(for intent: SelectedBookIntent, with completion: @escaping (BookSelectionResolutionResult) -> Void) {
-        
+    func resolveSelectedBook(for intent: SelectedBookIntent, with completion: @escaping (BookSelectionResolutionResult) -> Void) {
+        // only needed for protocol conformance
     }
     
-    func provideParameterOptionsCollection(for intent: SelectedBookIntent, with completion: @escaping (INObjectCollection<BookSelection>?, Error?) -> Void) {
+    func resolveDetails(for intent: SelectedBookIntent, with completion: @escaping (WidgetDetailsResolutionResult) -> Void) {
+        // only needed for protocol conformance
+    }
+    
+    func provideSelectedBookOptionsCollection(for intent: SelectedBookIntent, with completion: @escaping (INObjectCollection<BookSelection>?, Error?) -> Void) {
         let bookOptions: [BookSelection] = BookStore().activeBooks.map { book in
             BookSelection(identifier: book.title, display: book.title)
         }
@@ -22,7 +26,6 @@ class IntentHandler: INExtension, SelectedBookIntentHandling {
         
         completion(collection, nil)
     }
-    
     
     override func handler(for intent: INIntent) -> Any {
         // This is the default implementation.  If you want different objects to handle different intents,

--- a/SelectedBookWidget/SelectedBookIntent.intentdefinition
+++ b/SelectedBookWidget/SelectedBookIntent.intentdefinition
@@ -3,7 +3,71 @@
 <plist version="1.0">
 <dict>
 	<key>INEnums</key>
-	<array/>
+	<array>
+		<dict>
+			<key>INEnumDisplayName</key>
+			<string>Widget Details</string>
+			<key>INEnumDisplayNameID</key>
+			<string>ODq7Ql</string>
+			<key>INEnumGeneratesHeader</key>
+			<true/>
+			<key>INEnumName</key>
+			<string>WidgetDetails</string>
+			<key>INEnumType</key>
+			<string>Regular</string>
+			<key>INEnumValues</key>
+			<array>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>unknown</string>
+					<key>INEnumValueDisplayNameID</key>
+					<string>pEj9Fv</string>
+					<key>INEnumValueName</key>
+					<string>unknown</string>
+				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Today's Target Page</string>
+					<key>INEnumValueDisplayNameID</key>
+					<string>IixmMn</string>
+					<key>INEnumValueIndex</key>
+					<integer>1</integer>
+					<key>INEnumValueName</key>
+					<string>todaysTarget</string>
+				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Current Page</string>
+					<key>INEnumValueDisplayNameID</key>
+					<string>qbyo2r</string>
+					<key>INEnumValueIndex</key>
+					<integer>2</integer>
+					<key>INEnumValueName</key>
+					<string>currentPage</string>
+				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Percent Complete</string>
+					<key>INEnumValueDisplayNameID</key>
+					<string>TFYqRk</string>
+					<key>INEnumValueIndex</key>
+					<integer>3</integer>
+					<key>INEnumValueName</key>
+					<string>percentage</string>
+				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Pages Left Today</string>
+					<key>INEnumValueDisplayNameID</key>
+					<string>HTwPt7</string>
+					<key>INEnumValueIndex</key>
+					<integer>4</integer>
+					<key>INEnumValueName</key>
+					<string>pagesLeft</string>
+				</dict>
+			</array>
+		</dict>
+	</array>
 	<key>INIntentDefinitionModelVersion</key>
 	<string>1.2</string>
 	<key>INIntentDefinitionNamespace</key>
@@ -28,7 +92,7 @@
 			<key>INIntentIneligibleForSuggestions</key>
 			<true/>
 			<key>INIntentLastParameterTag</key>
-			<integer>2</integer>
+			<integer>4</integer>
 			<key>INIntentName</key>
 			<string>SelectedBook</string>
 			<key>INIntentParameters</key>
@@ -45,11 +109,46 @@
 					<key>INIntentParameterDisplayPriority</key>
 					<integer>1</integer>
 					<key>INIntentParameterName</key>
-					<string>parameter</string>
+					<string>selectedBook</string>
 					<key>INIntentParameterObjectType</key>
 					<string>BookSelection</string>
 					<key>INIntentParameterObjectTypeNamespace</key>
 					<string>88xZPY</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} options matching ‘${selectedBook}’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>miPZeY</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${selectedBook}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>tHbZtN</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
 					<key>INIntentParameterSupportsDynamicEnumeration</key>
 					<true/>
 					<key>INIntentParameterSupportsResolution</key>
@@ -58,6 +157,70 @@
 					<integer>2</integer>
 					<key>INIntentParameterType</key>
 					<string>Object</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterCustomDisambiguation</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>Details</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>2qoMn2</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>2</integer>
+					<key>INIntentParameterEnumType</key>
+					<string>WidgetDetails</string>
+					<key>INIntentParameterEnumTypeNamespace</key>
+					<string>88xZPY</string>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataDefaultValue</key>
+						<string>todaysTarget</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>details</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} options matching ‘${details}’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>3Ouybg</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${details}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>EAC5pw</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterSupportsResolution</key>
+					<true/>
+					<key>INIntentParameterTag</key>
+					<integer>4</integer>
+					<key>INIntentParameterType</key>
+					<string>Integer</string>
 				</dict>
 			</array>
 			<key>INIntentResponse</key>


### PR DESCRIPTION
## Release notes (1.0, build 5)
- This build may initially reset the selected book in any widget instances to the first book in your Now Reading list. Re-configuring the widget to the book of your choice will fix it. This won’t happen again in future builds, just a casualty of some work related to the next item below…
- You can now choose which details about the book get displayed at the bottom of the widget. Just long-press on the widget to bring up the context menu, then choose “Edit Widget” to configure it.
- Adds the time your daily target was last calculated to the Book Details screen
