### PR TITLE
Build 10

### DIFF
--- a/ReadRate.xcodeproj/project.pbxproj
+++ b/ReadRate.xcodeproj/project.pbxproj
@@ -466,7 +466,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -491,7 +491,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -514,7 +514,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookIntentsExtension/SelectedBookIntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookIntentsExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -537,7 +537,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookIntentsExtension/SelectedBookIntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookIntentsExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -678,7 +678,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ReadRate/Read Rate.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_ASSET_PATHS = "\"ReadRate/Preview Content\"";
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				ENABLE_PREVIEWS = YES;
@@ -703,7 +703,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ReadRate/Read Rate.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 8;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_ASSET_PATHS = "\"ReadRate/Preview Content\"";
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				ENABLE_PREVIEWS = YES;

--- a/ReadRate.xcodeproj/xcuserdata/evanfreeze.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/ReadRate.xcodeproj/xcuserdata/evanfreeze.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,17 +7,17 @@
 		<key>ReadRate.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>2</integer>
 		</dict>
 		<key>SelectedBookIntentsExtension.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>0</integer>
 		</dict>
 		<key>SelectedBookWidgetExtension.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/ReadRate/Models/BookModel.swift
+++ b/ReadRate/Models/BookModel.swift
@@ -218,7 +218,11 @@ struct Book: Identifiable, Codable, Comparable {
     
     // MARK: Methods
     func getCompletionPercentage() -> Double {
-        return Double(currentPage) / Double(pageCount)
+        if pageCount > 0 {
+            return Double(currentPage) / Double(pageCount)
+        } else {
+            return 0
+        }
     }
 
     func getPagesPerDay() -> Int {

--- a/ReadRate/Models/BookModel.swift
+++ b/ReadRate/Models/BookModel.swift
@@ -243,7 +243,7 @@ struct Book: Identifiable, Codable, Comparable {
     
     func getReadingDaysFromDates(start: Date) -> Double {
         let days = Calendar.current.dateComponents([.day], from: start, to: targetDate).day!
-        return Double(days + 2)
+        return Double(days + 1)
     }
     
     // MARK: Comparable Conformance

--- a/ReadRate/Views/BookDetails.swift
+++ b/ReadRate/Views/BookDetails.swift
@@ -90,6 +90,15 @@ struct BookDetail: View {
             }
         )
         
+        let bookPageCount = Binding<String>(
+            get: {
+                "\(book.pageCount)"
+            },
+            set: {
+                book.pageCount = Int($0)!
+            }
+        )
+        
         return HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
@@ -205,6 +214,8 @@ struct BookDetail: View {
                     LabeledInput(label: "Title", placeholder: "The name of the book", value: $book.title)
                     LabeledInput(label: "Author", placeholder: "Who wrote the book", value: $book.author)
                     LabeledInput(label: "The book's ISBN", placeholder: "ISBN (used to find cover art)", value: bookISBN).keyboardType(.numberPad)
+                    LabeledInput(label: "Page Count", placeholder: "Total number of pages in the book", value: bookPageCount)
+                        .keyboardType(.numberPad)
                     DatePicker(
                         selection: $book.startDate,
                         displayedComponents: .date,


### PR DESCRIPTION
# Release Notes (1.0, build 10)

### A few bug fixes —
- Fixes an issue that would crash the app if the total page count of a book was 0 and you tried to view that book’s details
- Fixes an issue that would sometimes occur when counting how many days remain until your target completion date (used in the “Today’s Goal” calculation)

### Minor addition —
- You can now edit the total page count of the book from the "Edit" screen — for those occasions where you maybe mistyped it when you added the book.
