### PR TITLE
Build 15

### DIFF
--- a/ReadRate.xcodeproj/project.pbxproj
+++ b/ReadRate.xcodeproj/project.pbxproj
@@ -590,7 +590,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -615,7 +615,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookWidgetExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -638,7 +638,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookIntentsExtension/SelectedBookIntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookIntentsExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -661,7 +661,7 @@
 				CODE_SIGN_ENTITLEMENTS = SelectedBookIntentsExtension/SelectedBookIntentsExtension.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				INFOPLIST_FILE = SelectedBookIntentsExtension/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -802,7 +802,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ReadRate/Read Rate.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_ASSET_PATHS = "\"ReadRate/Preview Content\"";
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				ENABLE_PREVIEWS = YES;
@@ -827,7 +827,7 @@
 				CODE_SIGN_ENTITLEMENTS = "ReadRate/Read Rate.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEVELOPMENT_ASSET_PATHS = "\"ReadRate/Preview Content\"";
 				DEVELOPMENT_TEAM = 4BSVL8X5HC;
 				ENABLE_PREVIEWS = YES;

--- a/ReadRate/Models/BookModel.swift
+++ b/ReadRate/Models/BookModel.swift
@@ -221,7 +221,7 @@ struct Book: Identifiable, Codable, Comparable, HasReadingGoal {
             }
         case .rate:
             let rateGoalAtLastGoalCalculation = dailyTargets.last?.meta.rateGoal ?? rateGoal
-            if rateGoal! != rateGoalAtLastGoalCalculation {
+            if rateGoal != rateGoalAtLastGoalCalculation {
                 goalInputsChangedSinceLastUpdate = true
             }
         }

--- a/ReadRate/Views/Add Book Screen/AddBook.swift
+++ b/ReadRate/Views/Add Book Screen/AddBook.swift
@@ -159,7 +159,7 @@ struct AddBook: View {
             targetDate: self.targetDate,
             ISBN: isbn.cleanedNumeric(),
             mode: self.mode,
-            rateGoal: self.mode == .rate ? readingRate : nil
+            rateGoal: readingRate
         )
         
         if newBook.ISBN != nil && newBook.ISBN!.count > 0 {

--- a/ReadRate/Views/Book Details Screen/BookDetails.swift
+++ b/ReadRate/Views/Book Details Screen/BookDetails.swift
@@ -200,7 +200,7 @@ struct BookDetail: View {
         
         let rateGoal = Binding<Int>(
             get: {
-                book.rateGoal!
+                book.rateGoal ?? 5
             },
             set: {
                 book.rateGoal = $0


### PR DESCRIPTION
# Release Notes (1.0, build 15)

## Build 15 —
- The last build fixed one of the places a certain crash was happening — this one should fix the other place it pops up.

## Notes from this morning’s build (14) —

### New —

- Widgets should auto-refresh after midnight. No more seeing your leftover progress from yesterday until you open the app.

### Fixed — 

- Fix for a crash that could occasionally occur when setting a Pages Per Day goal
- Some UI clean up on the “Set Your Goal” screen
- Fixes an issue where the scrollbar would overlap the content on the “Archived Books” screen
